### PR TITLE
changed libwebsockets version to a fixed release

### DIFF
--- a/installDependencies.sh
+++ b/installDependencies.sh
@@ -8,7 +8,7 @@ set -e
 # Libwebsockets
 sudo apt install libssl-dev
 cd /tmp
-git clone https://github.com/warmcat/libwebsockets.git
+git clone --depth 1 -b v4.0.15 https://github.com/warmcat/libwebsockets.git
 cd libwebsockets
 mkdir build && cd build
 cmake ..


### PR DESCRIPTION
Changes to libwebsockets dependecy caused build issues at https://github.com/SoPra-Team-17/Server/pull/144. To fix these and prevent new problems, the version is now fixed to a release.